### PR TITLE
Add Gemini model integration

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model interfaces for ArtemisAI."""
+
+from .gemini import generate
+
+__all__ = ["generate"]

--- a/src/models/gemini.py
+++ b/src/models/gemini.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+
+import google.generativeai as genai
+
+from security.secrets_manager import SecretsManager
+
+_api_key = SecretsManager().retrieve("GEMINI_API_KEY")
+if not _api_key:
+    raise RuntimeError("GEMINI_API_KEY not found in secrets manager.")
+
+genai.configure(api_key=_api_key)
+
+
+async def generate(prompt: str, **kwargs) -> str:
+    """Generate a response from Google's Gemini model.
+
+    Parameters
+    ----------
+    prompt: str
+        Prompt to send to the model.
+    **kwargs:
+        Additional parameters passed to ``GenerativeModel`` and
+        ``generate_content``. ``model_name`` defaults to ``\"gemini-pro\"``.
+
+    Returns
+    -------
+    str
+        The text output from the model.
+    """
+    model_name = kwargs.pop("model_name", "gemini-pro")
+    model = genai.GenerativeModel(model_name)
+    response = await asyncio.to_thread(model.generate_content, prompt, **kwargs)
+    return response.text


### PR DESCRIPTION
## Summary
- add Gemini client backed by google-generativeai
- expose async generate function

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af427623248321b9c35331aa820900