### PR TITLE
Add basic memory stores with time-decayed retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 secret.key
 secrets.dat
 __pycache__/
+data/

--- a/src/kv_store.py
+++ b/src/kv_store.py
@@ -1,0 +1,32 @@
+"""Simple persistent key/value store backed by JSON."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+class KVStore:
+    """A tiny JSON backed key/value store."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.data: Dict[str, Any] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            self.data = json.loads(self.path.read_text())
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self.data))
+
+    def set(self, key: str, value: Any) -> None:
+        """Store ``value`` under ``key`` and persist immediately."""
+        self.data[key] = value
+        self._save()
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        """Retrieve a value by ``key`` returning ``default`` when missing."""
+        return self.data.get(key, default)

--- a/src/memory.py
+++ b/src/memory.py
@@ -1,0 +1,44 @@
+"""Memory API combining key/value and semantic stores with decay."""
+from __future__ import annotations
+
+import math
+import time
+from pathlib import Path
+from typing import List
+
+from kv_store import KVStore
+from vector_store import VectorStore
+
+DATA_DIR = Path("data")
+KV_PATH = DATA_DIR / "kv_store.json"
+VEC_PATH = DATA_DIR / "vector_store.json"
+DECAY_SECONDS = 60 * 60 * 24  # one day
+
+_kv = KVStore(KV_PATH)
+_vec = VectorStore(VEC_PATH)
+
+
+def _decay(ts: float, now: float) -> float:
+    return math.exp(-(now - ts) / DECAY_SECONDS)
+
+
+def write_memory(key: str, text: str) -> None:
+    """Persist ``text`` under ``key`` and index for semantic search."""
+    ts = time.time()
+    _kv.set(key, {"text": text, "timestamp": ts})
+    _vec.add(text, {"key": key, "timestamp": ts})
+
+
+def retrieve_memory(query: str, top_k: int = 5) -> List[str]:
+    """Retrieve memories relevant to ``query`` with time decay."""
+    now = time.time()
+    results = []
+    item = _kv.get(query)
+    if isinstance(item, dict) and "timestamp" in item:
+        results.append({"text": item["text"], "score": _decay(item["timestamp"], now)})
+    for res in _vec.search(query, top_k):
+        ts = res.get("metadata", {}).get("timestamp", now)
+        score = res["score"] * _decay(ts, now)
+        results.append({"text": res["text"], "score": score})
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return [r["text"] for r in results[:top_k]]

--- a/src/vector_store.py
+++ b/src/vector_store.py
@@ -1,0 +1,95 @@
+"""Semantic vector store using FAISS when available with JSON fallback."""
+from __future__ import annotations
+
+import json
+import math
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:  # pragma: no cover - optional dependency
+    import faiss  # type: ignore
+    import numpy as np  # type: ignore
+    _FAISS = True
+except Exception:  # pragma: no cover - faiss absent
+    faiss = None  # type: ignore
+    np = None  # type: ignore
+    _FAISS = False
+
+
+class VectorStore:
+    """Persisted store supporting rudimentary semantic search."""
+
+    def __init__(self, path: Path, dim: int = 128) -> None:
+        self.path = path
+        self.dim = dim
+        self.texts: List[str] = []
+        self.metadatas: List[Dict[str, Any]] = []
+        self.vectors: List[List[float]] = []
+        self.use_faiss = _FAISS
+        if self.use_faiss:
+            self.index = faiss.IndexFlatIP(dim)  # type: ignore[assignment]
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _embed(self, text: str) -> List[float]:
+        vec = [0.0] * self.dim
+        for token in text.lower().split():
+            h = int(hashlib.md5(token.encode()).hexdigest(), 16)
+            vec[h % self.dim] += 1.0
+        norm = math.sqrt(sum(v * v for v in vec))
+        if norm:
+            vec = [v / norm for v in vec]
+        return vec
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        data = json.loads(self.path.read_text())
+        self.texts = data.get("texts", [])
+        self.metadatas = data.get("metadatas", [])
+        self.vectors = data.get("vectors", [])
+        if self.use_faiss and self.vectors:
+            arr = np.array(self.vectors, dtype="float32")  # type: ignore[call-arg]
+            self.index.add(arr)
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        data = {"texts": self.texts, "metadatas": self.metadatas, "vectors": self.vectors}
+        self.path.write_text(json.dumps(data))
+
+    # ------------------------------------------------------------------
+    def add(self, text: str, metadata: Dict[str, Any] | None = None) -> None:
+        metadata = metadata or {}
+        emb = self._embed(text)
+        self.texts.append(text)
+        self.metadatas.append(metadata)
+        self.vectors.append(emb)
+        if self.use_faiss:
+            self.index.add(np.array([emb], dtype="float32"))  # type: ignore[call-arg]
+        self._save()
+
+    # ------------------------------------------------------------------
+    def search(self, query: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        if not self.texts:
+            return []
+        emb = self._embed(query)
+        if self.use_faiss:
+            scores, idxs = self.index.search(np.array([emb], dtype="float32"), top_k)  # type: ignore[call-arg]
+            results = []
+            for score, idx in zip(scores[0], idxs[0]):
+                if idx == -1:
+                    continue
+                results.append({
+                    "text": self.texts[idx],
+                    "metadata": self.metadatas[idx],
+                    "score": float(score),
+                })
+            return results
+        scores = [sum(a * b for a, b in zip(emb, vec)) for vec in self.vectors]
+        ranked = sorted(enumerate(scores), key=lambda x: x[1], reverse=True)[:top_k]
+        return [
+            {"text": self.texts[i], "metadata": self.metadatas[i], "score": float(s)}
+            for i, s in ranked
+        ]


### PR DESCRIPTION
## Summary
- add JSON-based KV store
- implement vector store with FAISS or pure Python fallback
- expose memory APIs for writing and retrieving with time decay

## Testing
- `python3 -m py_compile src/kv_store.py src/vector_store.py src/memory.py`
- `pytest -q` *(fails: command not found)*
- `pip3 install pytest --break-system-packages` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68af42f6cbf883218563c30463e5bb57