### PR TITLE
feat: add model routing manager

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,1 @@
+"""Model backends for ArtemisAI."""

--- a/src/models/gemini.py
+++ b/src/models/gemini.py
@@ -1,0 +1,17 @@
+"""Placeholder Gemini backend."""
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+
+def generate(task: str, context: Dict[str, Any] | None = None) -> Tuple[str, int]:
+    """Generate a dummy response for ``task``.
+
+    This simple placeholder echoes the task and returns a naive token
+    count based on whitespace splitting.  Real implementations would
+    call the Gemini API.
+    """
+    context = context or {}
+    response = f"Echo: {task}"
+    tokens = len(task.split())
+    return response, tokens

--- a/src/models/manager.py
+++ b/src/models/manager.py
@@ -1,0 +1,47 @@
+"""Dispatch requests to model backends."""
+from __future__ import annotations
+
+import time
+from importlib import import_module
+from typing import Any, Callable, Dict, Tuple
+
+# Map model identifiers to their generation callables
+_BACKENDS: Dict[str, str] = {
+    "gemini": "models.gemini.generate",
+}
+
+
+def _get_backend(path: str) -> Callable[[str, Dict[str, Any] | None], Tuple[str, int]]:
+    """Return the backend callable from an import path."""
+    module_name, func_name = path.rsplit(".", 1)
+    module = import_module(module_name)
+    return getattr(module, func_name)
+
+
+def run(task: str, context: Dict[str, Any] | None, model_id: str = "gemini") -> Tuple[str, Dict[str, float]]:
+    """Execute a model backend and return the result with metadata.
+
+    Parameters
+    ----------
+    task:
+        Prompt or instruction for the model.
+    context:
+        Additional information for generation.
+    model_id:
+        Identifier of the model backend to use.  Defaults to ``"gemini"``.
+
+    Returns
+    -------
+    tuple
+        A tuple of the generated response and a metadata dictionary
+        containing ``tokens`` and ``latency``.
+    """
+    if model_id not in _BACKENDS:
+        raise ValueError(f"Unsupported model_id '{model_id}'")
+
+    generate = _get_backend(_BACKENDS[model_id])
+    start = time.perf_counter()
+    response, tokens = generate(task, context)
+    latency = time.perf_counter() - start
+    metadata = {"tokens": float(tokens), "latency": latency}
+    return response, metadata


### PR DESCRIPTION
## Summary
- add model manager that dispatches requests to Gemini backend
- include placeholder Gemini backend and package init

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af42d3d7f08321aa8bd45506d7b5e8