### PR TITLE
Add alerting module with adapters and scheduler integration

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,2 +1,13 @@
 Artemis AI
-first commit.
+
+Utilities for coordinating security sensitive operations.
+
+## Alerting
+
+Use ``src/alerts.py`` to route notifications to different channels::
+
+    from alerts import send
+    send("email", "Job complete")
+
+The ``Scheduler`` and ``Orchestrator`` modules can both trigger alerts using
+this function.

--- a/src/alerts.py
+++ b/src/alerts.py
@@ -1,0 +1,68 @@
+"""Alerting utilities with simple channel adapters.
+
+This module exposes a :func:`send` function which routes a message to a
+channel specific adapter.  Adapters for text-to-speech (TTS), mobile push
+notifications and email are provided as basic examples.  Each adapter simply
+prints to stdout but is structured so real integrations can be swapped in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Protocol
+
+
+class AlertAdapter(Protocol):
+    """Protocol for alert channel adapters."""
+
+    def send(self, message: str) -> None:
+        """Deliver ``message`` through the channel."""
+
+
+@dataclass
+class TTSAdapter:
+    """Convert the message to speech."""
+
+    def send(self, message: str) -> None:  # pragma: no cover - placeholder
+        print(f"[TTS] {message}")
+
+
+@dataclass
+class PushAdapter:
+    """Push a notification to a mobile device."""
+
+    def send(self, message: str) -> None:  # pragma: no cover - placeholder
+        print(f"[PUSH] {message}")
+
+
+@dataclass
+class EmailAdapter:
+    """Send the message via email."""
+
+    def send(self, message: str) -> None:  # pragma: no cover - placeholder
+        print(f"[EMAIL] {message}")
+
+
+_ADAPTERS: Dict[str, AlertAdapter] = {
+    "tts": TTSAdapter(),
+    "push": PushAdapter(),
+    "email": EmailAdapter(),
+}
+
+
+def send(channel: str, message: str) -> None:
+    """Dispatch ``message`` to the specified ``channel``.
+
+    Parameters
+    ----------
+    channel:
+        One of ``"tts"``, ``"push"`` or ``"email"``.
+    message:
+        Text to deliver.
+    """
+
+    adapter = _ADAPTERS.get(channel)
+    if adapter is None:
+        raise ValueError(f"Unknown alert channel: {channel}")
+    adapter.send(message)
+

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Callable, Any
+from typing import Any, Callable
+
+from alerts import send as send_alert
 
 from security.secrets_manager import SecretsManager
 
@@ -42,6 +44,11 @@ class Orchestrator:
                 return None
             _logger.info("Approved privileged command '%s'", func.__name__)
         return func(*args, **kwargs)
+
+    def alert(self, channel: str, message: str) -> None:
+        """Trigger an alert using the shared alerting module."""
+
+        send_alert(channel, message)
 
     # Example sensitive operation ------------------------------------------------
     def store_secret(self, name: str, secret: str) -> None:

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -1,0 +1,22 @@
+"""Very small scheduler capable of sending delayed alerts."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from alerts import send
+
+
+class Scheduler:
+    """Execute callbacks after a delay."""
+
+    def alert_in(self, delay: float, channel: str, message: str) -> None:
+        """Send ``message`` to ``channel`` after ``delay`` seconds."""
+
+        def _task() -> None:
+            time.sleep(delay)
+            send(channel, message)
+
+        threading.Thread(target=_task, daemon=True).start()
+


### PR DESCRIPTION
## Summary
- add `send(channel, message)` with TTS, push, and email adapters
- allow orchestrator and scheduler to trigger alerts through shared module
- document alert usage in README

## Testing
- `python3 -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68af43214e708321bb4d8622c0d0447f