### PR TITLE
Add structured logging, metrics, and tracing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+prometheus_client
+opentelemetry-api
+opentelemetry-sdk

--- a/src/logging_setup.py
+++ b/src/logging_setup.py
@@ -1,0 +1,62 @@
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+class JsonFormatter(logging.Formatter):
+    """Format logs as JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        log_record = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        # Include any extra fields set on the record.
+        for key, value in record.__dict__.items():
+            if key not in {
+                "name",
+                "msg",
+                "args",
+                "levelname",
+                "levelno",
+                "pathname",
+                "filename",
+                "module",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "lineno",
+                "funcName",
+                "created",
+                "msecs",
+                "relativeCreated",
+                "thread",
+                "threadName",
+                "processName",
+                "process",
+            }:
+                log_record[key] = value
+        return json.dumps(log_record)
+
+
+def setup_logging(log_file: Optional[Path] = None) -> None:
+    """Configure root logger to output JSON."""
+
+    formatter = JsonFormatter()
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.handlers = [handler]
+
+    if log_file is not None:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,44 @@
+import time
+from functools import wraps
+from typing import Callable, TypeVar, Any
+
+from prometheus_client import Counter, Histogram, start_http_server
+
+# Metrics definitions
+REQUEST_LATENCY = Histogram(
+    "function_latency_seconds", "Latency of function calls", ["function"]
+)
+REQUEST_ERRORS = Counter(
+    "function_errors_total", "Total errors", ["function"]
+)
+
+_METRICS_STARTED = False
+
+
+def start_metrics_server(port: int = 8000) -> None:
+    """Expose metrics on the given port."""
+    global _METRICS_STARTED
+    if not _METRICS_STARTED:
+        start_http_server(port)
+        _METRICS_STARTED = True
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def track_metrics(func: F) -> F:
+    """Decorator to record latency and errors for ``func``."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any):
+        start = time.perf_counter()
+        try:
+            result = func(*args, **kwargs)
+        except Exception:
+            REQUEST_ERRORS.labels(func.__name__).inc()
+            REQUEST_LATENCY.labels(func.__name__).observe(time.perf_counter() - start)
+            raise
+        REQUEST_LATENCY.labels(func.__name__).observe(time.perf_counter() - start)
+        return result
+
+    return wrapper  # type: ignore[return-value]

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1,22 +1,28 @@
-"""Orchestrator module with permission prompts and audit logging."""
+"""Orchestrator module with permission prompts, metrics and tracing."""
 from __future__ import annotations
 
 import logging
 from pathlib import Path
 from typing import Callable, Any
 
+from logging_setup import JsonFormatter, setup_logging
+from metrics import start_metrics_server, track_metrics
 from security.secrets_manager import SecretsManager
+from tracing import traced
 
 # ---------------------------------------------------------------------------
-# Configure audit logging
+# Global logging/metrics setup
+setup_logging()
+start_metrics_server()
+
+# Configure audit logging to a file using JSON structure
 LOG_PATH = Path("logs/security.log")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 _logger = logging.getLogger("security")
 _logger.setLevel(logging.INFO)
-_handler = logging.FileHandler(LOG_PATH)
-_formatter = logging.Formatter("%(asctime)s - %(message)s")
-_handler.setFormatter(_formatter)
-_logger.addHandler(_handler)
+_file_handler = logging.FileHandler(LOG_PATH)
+_file_handler.setFormatter(JsonFormatter())
+_logger.addHandler(_file_handler)
 
 
 class Orchestrator:
@@ -29,6 +35,8 @@ class Orchestrator:
         response = input(f"{message} (y/n): ").strip().lower()
         return response == "y"
 
+    @traced
+    @track_metrics
     def run(self, func: Callable[..., Any], *args: Any, privileged: bool = False, **kwargs: Any) -> Any:
         """Execute ``func`` optionally requiring privilege.
 
@@ -36,14 +44,18 @@ class Orchestrator:
         before execution.  The attempt is logged to ``logs/security.log``.
         """
         if privileged:
-            if not self._confirm(f"Privileged action '{func.__name__}' requested. Proceed?"):
-                _logger.info("Denied privileged command '%s'", func.__name__)
+            if not self._confirm(
+                f"Privileged action '{func.__name__}' requested. Proceed?"
+            ):
+                _logger.info("Denied privileged command", extra={"function": func.__name__})
                 print("Action cancelled.")
                 return None
-            _logger.info("Approved privileged command '%s'", func.__name__)
+            _logger.info("Approved privileged command", extra={"function": func.__name__})
         return func(*args, **kwargs)
 
     # Example sensitive operation ------------------------------------------------
+    @traced
+    @track_metrics
     def store_secret(self, name: str, secret: str) -> None:
         """Store a credential securely after confirmation."""
         self.run(lambda: self.secrets.store(name, secret), privileged=True)

--- a/src/tracing.py
+++ b/src/tracing.py
@@ -1,0 +1,31 @@
+from functools import wraps
+from typing import Callable, TypeVar, Any
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
+
+    trace.set_tracer_provider(TracerProvider())
+    trace.get_tracer_provider().add_span_processor(
+        SimpleSpanProcessor(ConsoleSpanExporter())
+    )
+    _tracer = trace.get_tracer(__name__)
+except Exception:  # pragma: no cover - optional dependency
+    _tracer = None
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def traced(func: F) -> F:
+    """Decorator to create a span around ``func`` if tracing is available."""
+
+    if _tracer is None:
+        return func
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any):
+        with _tracer.start_as_current_span(func.__name__):
+            return func(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]


### PR DESCRIPTION
## Summary
- implement JSON-formatted logging with a shared setup and audit file output
- instrument functions with Prometheus metrics and optional OpenTelemetry tracing
- expose metrics server and add utility modules

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement prometheus_client)*
- `python -m pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af437195648321bd10fad43ce4e0e5